### PR TITLE
Adding credentials_provider_class support

### DIFF
--- a/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java
+++ b/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java
@@ -30,14 +30,16 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.jgroups.PhysicalAddress;
-import org.jgroups.protocols.Discovery;
-import org.jgroups.stack.IpAddress;
 import org.jgroups.annotations.Property;
 import org.jgroups.conf.ClassConfigurator;
+import org.jgroups.protocols.Discovery;
+import org.jgroups.stack.IpAddress;
+import org.jgroups.util.Util;
 import org.w3c.dom.Node;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.Request;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.handlers.RequestHandler;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -149,9 +151,8 @@ public class AWS_PING extends Discovery {
                                                                 // be unique
   }
 
-  @Property(description = "The AWS Credentials Chain Class to use when searching for the account .")
+  @Property(description = "The AWS Credentials Chain Class to use when searching for the account.")
   protected String credentials_provider_class = com.amazonaws.auth.DefaultAWSCredentialsProviderChain.class.getName();
-
   @Property(description = "The AWS Access Key for the account to search.")
   protected String access_key;
   @Property(description = "The AWS Secret Key for the account to search.")
@@ -246,7 +247,10 @@ public class AWS_PING extends Discovery {
 
     // start up a new ec2 client with the region specific endpoint.
     if( access_key == null && secret_key == null ) {
-      ec2 = new AmazonEC2Client((com.amazonaws.auth.AWSCredentialsProvider) Class.forName(credentials_provider_class).newInstance());
+      Class<?> credsProviderClazz = Util.loadClass(credentials_provider_class, null);
+      AWSCredentialsProvider awsCredentialsProvider = (AWSCredentialsProvider) credsProviderClazz.newInstance();
+
+      ec2 = new AmazonEC2Client(awsCredentialsProvider);
     }
     else {
       ec2 = new AmazonEC2Client(new BasicAWSCredentials(access_key, secret_key));


### PR DESCRIPTION
Hey,

First: Thanks for this one. It came handy for an Atmosphere-based Project I'm doing (https://bitbucket.org/aldrinleal/elasticbeanstalk-atmosphere-sample)

However, the way it works is not compatible with AWS Elastic Beanstalk, since it does not (yet) uses Instance Roles, but instead, map into a container-dependent fashion (for Java, it exports as System Properties)

The default way for the AWS Java SDK is:
- When empty, use DefaultAWSCredentialsProvider ctor, which does a chain (it involves System Role, Environment Variables, and others)
- If you pass a AWSCredentialsProvider class name, it will instantiate and use it (we've made a custom one for Elastic Beanstalk Apps on our Maven Archetype)
- Otherwise, supply hard-coded BasicAWSCredentials

I've extended the AWS_PING class to support a credentials_provider_class with the default set to the DefaultAWSCredentials Provider, so when missing access/secret key, there should be no change.

(Then I'll have to patch further, in order to use AWS EB / EC2 Metadata to figure out my environment, but this is not a concern. Really)

Thank you
