### PR TITLE
Removed compile time dependency on slf4j-simple.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,14 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.5.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.5.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Replaced it with slf4j-api in the compiled jar. This is because slf4j-simple conflicts with several other logging solutions. By swapping to the api only these issues are avoided.