### PR TITLE
Updated AWS-Java-SDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.3.26</version>
+      <version>1.10.40</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Authentication does not work with the older aws-java-sdk, at least on eu-central-1. Probably caused by signature versions which are not supported in the older SDK. Re-compiling against a later SDK resolved the issue. It would be good to have this on the official release and repositories.