### PR TITLE
Protocol doesn't work when port_range is 0

### DIFF
--- a/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java
+++ b/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java
@@ -326,7 +326,7 @@ public class AWS_PING extends Discovery {
 
     List<PhysicalAddress> clusterMembers = new ArrayList<PhysicalAddress>();
     for (String privateIpAddress : getPrivateIpAddresses()) {
-      for (int i = port_number; i < port_number + port_range; i++) {
+      for (int i = port_number; i <= port_number + port_range; i++) {
         try {
           clusterMembers.add(new IpAddress(privateIpAddress, i));
         } catch (UnknownHostException e) {


### PR DESCRIPTION
The documentation says that setting port_range to 0 should not scan additional ports, but if it is set to 0, it does not work. In the for loop does a less than comparator, which will always be false when the port_range is 0.

https://github.com/meltmedia/jgroups-aws/blob/develop/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java#L329

Simply changing it to <= fixes it.