### PR TITLE
Simplifies AWS dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>1.10.40</version>
+      <artifactId>aws-java-sdk-ec2</artifactId>
+      <version>1.11.125</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This _should_ be sufficient to modernise the AWS SDK dependency. Dependence on `aws-java-sdk` pulls in _all_ the SDK JARs these days, and `AWS_PING` would appear only to need the EC2 SDK.

Project unit tests all pass with this change, but it would be good to test this a bit more widely before merging it in. Is anyone in a position to test this more extensively?