### PR TITLE
Optional tag validation (require_tags)

### DIFF
--- a/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java
+++ b/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java
@@ -189,7 +189,7 @@ public class AWS_PING extends Discovery {
         log_aws_error_messages);
 
     this.ipAddressUtils = new IPAddressUtils(port_number, port_range);
-    this.tagUtils = new TagsUtils(ec2, instanceIdentity, tags);
+    this.tagUtils = new TagsUtils(ec2, instanceIdentity, tags).validateTags();
     this.filterUtils = new FilterUtils(filters, tagUtils);
 
     log.info("Configured for instance: " + instanceIdentity.instanceId);

--- a/src/test/java/com/meltmedia/jgroups/aws/FilterUtilsTest.java
+++ b/src/test/java/com/meltmedia/jgroups/aws/FilterUtilsTest.java
@@ -61,7 +61,7 @@ public class FilterUtilsTest {
     final Tag instanceTag1 = new Tag("tag1", "value1");
     final Tag instanceTag2 = new Tag("tag2", "value2");
     final Tag instanceTag3 = new Tag("tag3", "value3");
-    final TagsUtils tagsUtils = new TagsUtils(ec2Mock(instanceTag1, instanceTag2, instanceTag3), instanceIdentity, "tag2, tag3, tag4");
+    final TagsUtils tagsUtils = new TagsUtils(ec2Mock(instanceTag1, instanceTag2, instanceTag3), instanceIdentity, "tag2, tag3");
     final FilterUtils filterUtils = new FilterUtils(null, tagsUtils);
 
     final List<Filter> filters = filterUtils.instanceTagNamesToFilters();

--- a/src/test/java/com/meltmedia/jgroups/aws/TagUtilsTest.java
+++ b/src/test/java/com/meltmedia/jgroups/aws/TagUtilsTest.java
@@ -32,11 +32,14 @@ public class TagUtilsTest {
 
   @Test
   public void willParseConfiguredTags() {
-    final TagsUtils tagsUtils = new TagsUtils(ec2Mock(), instanceIdentity, "configuredTag1, configuredTag2");
+    final Tag instanceTag1 = new Tag("tag1", "value1");
+    final Tag instanceTag2 = new Tag("tag2", "value2");
+
+    final TagsUtils tagsUtils = new TagsUtils(ec2Mock(instanceTag1, instanceTag2), instanceIdentity, "tag1, tag2").validateTags();
     assertTrue(tagsUtils.getAwsTagNames().isPresent());
     tagsUtils.getAwsTagNames().ifPresent(tags -> {
       assertEquals(2, tags.size());
-      assertArrayEquals(new String[]{"configuredTag1", "configuredTag2"}, tags.toArray());
+      assertArrayEquals(new String[]{"tag1", "tag2"}, tags.toArray());
     });
   }
 
@@ -45,7 +48,7 @@ public class TagUtilsTest {
     final Tag instanceTag1 = new Tag("instanceTag1", "value1");
     final Tag instanceTag2 = new Tag("instanceTag2", "value2");
 
-    final TagsUtils tagsUtils = new TagsUtils(ec2Mock(instanceTag1, instanceTag2), instanceIdentity, null);
+    final TagsUtils tagsUtils = new TagsUtils(ec2Mock(instanceTag1, instanceTag2), instanceIdentity, null).validateTags();
     final List<Tag> tags = tagsUtils.getInstanceTags();
 
     assertEquals(2, tags.size());
@@ -56,5 +59,13 @@ public class TagUtilsTest {
     assertEquals("value1", tag1.getValue());
     assertEquals("instanceTag2", tag2.getKey());
     assertEquals("value2", tag2.getValue());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void missingInstanceTagsShouldThrowException() {
+    final Tag instanceTag1 = new Tag("tag1", "value1");
+    final Tag instanceTag2 = new Tag("tag2", "value2");
+
+    new TagsUtils(ec2Mock(instanceTag1, instanceTag2), instanceIdentity, "tag1, tag2, tag3").validateTags();
   }
 }


### PR DESCRIPTION
Make it possible to require all configured tags to be present on the instance.