### PR TITLE
Fix for dropping nodes on same host in findMembers()

### DIFF
--- a/conf/aws_ping.xml
+++ b/conf/aws_ping.xml
@@ -42,11 +42,9 @@
     <pbcast.NAKACK2 use_mcast_xmit="false"
                    discard_delivered_msgs="true"/>
     <UNICAST3 />
-    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
+    <pbcast.STABLE desired_avg_gossip="50000"
                    max_bytes="4M"/>
-    <pbcast.GMS print_local_addr="true" join_timeout="3000"
-
-                view_bundling="true"/>
+    <pbcast.GMS print_local_addr="true" join_timeout="3000" />
     <UFC max_credits="2M"
          min_threshold="0.4"/>
     <MFC max_credits="2M"

--- a/conf/aws_ping.xml
+++ b/conf/aws_ping.xml
@@ -35,8 +35,8 @@
          secret_key="AWS_SECRET_KEY"/>
     <MERGE3  min_interval="10000"
              max_interval="30000"/>
-    <FD_SOCK/>
-    <FD timeout="3000" max_tries="3" />
+    <FD_SOCK />
+    <FD_ALL3 timeout="40000" interval="5000" />
     <VERIFY_SUSPECT timeout="1500"  />
     <BARRIER />
     <pbcast.NAKACK2 use_mcast_xmit="false"

--- a/conf/aws_ping.xml
+++ b/conf/aws_ping.xml
@@ -45,8 +45,6 @@
     <pbcast.STABLE desired_avg_gossip="50000"
                    max_bytes="4M"/>
     <pbcast.GMS print_local_addr="true" join_timeout="3000" />
-    <UFC max_credits="2M"
-         min_threshold="0.4"/>
     <MFC max_credits="2M"
          min_threshold="0.4"/>
     <FRAG2 frag_size="60K"  />

--- a/conf/aws_ping.xml
+++ b/conf/aws_ping.xml
@@ -17,7 +17,7 @@
 -->
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.0.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.0.xsd">
     <TCP bind_port="7800"
          recv_buf_size="${tcp.recv_buf_size:20M}"
          send_buf_size="${tcp.send_buf_size:640K}"

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.jgroups</groupId>
       <artifactId>jgroups</artifactId>
-      <version>4.0.5.Final</version>
+      <version>4.2.15.Final</version>
       <exclusions>
         <exclusion>
           <artifactId>bsh</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,13 +69,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.5.2</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.5.2</version>
-      <scope>test</scope>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java
+++ b/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java
@@ -236,7 +236,7 @@ public class AWS_PING extends Discovery {
 
     clusterMembers.stream()
         .filter(Objects::nonNull) //guard against nulls
-        .filter(address -> !address.getIpAddress().equals(physical_addr.getIpAddress())) //filter out self
+        .filter(address -> address.compareTo(physical_addr) != 0) //filter out self
         .map(address -> new Message(address)
             .setFlag(Message.Flag.INTERNAL, Message.Flag.DONT_BUNDLE, Message.Flag.OOB)
             .putHeader(this.id, hdr).setBuffer(marshal(data)))


### PR DESCRIPTION
The issue here is described at length in #29. Here we:

* make the change in `findMembers()` suggested by @ctrimble;
* update JGroups from 4.0.5 → 4.2.15;
* make various refinements to `conf/aws_ping.xml`, mostly suggested by JGroups itself at startup.
