### PR TITLE
Support for IMDSv2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-ec2</artifactId>
-      <version>1.11.125</version>
+      <version>1.11.1034</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java
+++ b/src/main/java/com/meltmedia/jgroups/aws/AWS_PING.java
@@ -15,12 +15,12 @@
  */
 package com.meltmedia.jgroups.aws;
 
+import com.amazonaws.internal.EC2ResourceFetcher;
+import com.amazonaws.internal.InstanceMetadataServiceResourceFetcher;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.Filter;
 import com.amazonaws.services.ec2.model.Instance;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.jgroups.Address;
 import org.jgroups.Event;
 import org.jgroups.Message;
@@ -175,9 +175,8 @@ public class AWS_PING extends Discovery {
     super.init();
 
     //get the instance identity
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
-      this.instanceIdentity = InstanceIdentity.getIdentity(client);
-    }
+    EC2ResourceFetcher ec2ResourceFetcher = InstanceMetadataServiceResourceFetcher.getInstance();
+    this.instanceIdentity = InstanceIdentity.getIdentity(ec2ResourceFetcher);
 
     //setup ec2 client
     this.ec2 = EC2Factory.create(

--- a/src/main/java/com/meltmedia/jgroups/aws/InstanceIdentity.java
+++ b/src/main/java/com/meltmedia/jgroups/aws/InstanceIdentity.java
@@ -1,13 +1,9 @@
 package com.meltmedia.jgroups.aws;
 
+import com.amazonaws.internal.EC2ResourceFetcher;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.net.URI;
@@ -56,26 +52,20 @@ public class InstanceIdentity {
     this.region = Objects.requireNonNull(region, "region cannot be null");
   }
 
-  public static InstanceIdentity getIdentity(final HttpClient client) throws IOException {
-    return new ObjectMapper().readValue(getIdentityDocument(client), InstanceIdentity.class);
+  public static InstanceIdentity getIdentity(EC2ResourceFetcher ec2ResourceFetcher) throws IOException {
+    return new ObjectMapper().readValue(getIdentityDocument(ec2ResourceFetcher), InstanceIdentity.class);
   }
 
   /**
    * Gets the body of the content returned from a GET request to uri.
    *
-   * @param client
    * @return the body of the message returned from the GET request.
    * @throws IOException if there is an error encountered while getting the content.
+   * @param ec2ResourceFetcher
    */
-  private static String getIdentityDocument(final HttpClient client) throws IOException {
+  private static String getIdentityDocument(EC2ResourceFetcher ec2ResourceFetcher) throws IOException {
     try {
-      final HttpGet getInstance = new HttpGet();
-      getInstance.setURI(INSTANCE_IDENTITY_URI);
-      final HttpResponse response = client.execute(getInstance);
-      if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-        throw new IOException("failed to get instance identity, tried: " + INSTANCE_IDENTITY_URL + ", response: " + response.getStatusLine().getReasonPhrase());
-      }
-      return EntityUtils.toString(response.getEntity());
+      return ec2ResourceFetcher.readResource(INSTANCE_IDENTITY_URI);
     } catch (Exception e) {
       throw new IOException("failed to get instance identity", e);
     }

--- a/src/test/java/com/meltmedia/jgroups/aws/InstanceIdentityTest.java
+++ b/src/test/java/com/meltmedia/jgroups/aws/InstanceIdentityTest.java
@@ -1,14 +1,10 @@
 package com.meltmedia.jgroups.aws;
 
+import com.amazonaws.internal.EC2ResourceFetcher;
 import com.google.common.io.Resources;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 
 import static com.google.common.io.Resources.getResource;
 import static org.junit.Assert.assertEquals;
@@ -19,19 +15,12 @@ import static org.mockito.Mockito.when;
 public class InstanceIdentityTest {
   @Test
   public void fromResponse() throws Exception {
-    final HttpClient client = mock(HttpClient.class);
-    final HttpResponse response = mock(HttpResponse.class);
-    final StatusLine statusLine = mock(StatusLine.class);
-    final HttpEntity responseEntity = mock(HttpEntity.class);
+    EC2ResourceFetcher ec2ResourceFetcher = mock(EC2ResourceFetcher.class);
 
-    when(responseEntity.getContent()).thenReturn(new ByteArrayInputStream(Resources.toByteArray(getResource("instance-identity.json"))));
-    when(responseEntity.getContentLength()).thenReturn(-1L);
-    when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
-    when(response.getStatusLine()).thenReturn(statusLine);
-    when(response.getEntity()).thenReturn(responseEntity);
-    when(client.execute(any())).thenReturn(response);
+    when(ec2ResourceFetcher.readResource(any(), any(), any()))
+            .thenReturn(Resources.toString(getResource("instance-identity.json"), StandardCharsets.UTF_8));
 
-    InstanceIdentity instanceIdentity = InstanceIdentity.getIdentity(client);
+    InstanceIdentity instanceIdentity = InstanceIdentity.getIdentity(ec2ResourceFetcher);
 
     assertEquals("us-west-2b", instanceIdentity.availabilityZone);
     assertEquals("10.158.112.84", instanceIdentity.privateIp);


### PR DESCRIPTION
Use internal classes to resolve instance meta data.  So it also works
when IMDSv2 is enforced.  